### PR TITLE
[reboot]: Fix reload flow for Mellanox platforms

### DIFF
--- a/scripts/reboot
+++ b/scripts/reboot
@@ -3,15 +3,18 @@
 REBOOT_USER=$(logname)
 REBOOT_TIME=$(date)
 PLATFORM=$(sonic-cfggen -H -v DEVICE_METADATA.localhost.platform)
+ASIC_TYPE=$(sonic-cfggen -y /etc/sonic/sonic_version.yml -v asic_type)
 DEVPATH="/usr/share/sonic/device"
 PLAT_REBOOT="platform_reboot"
 REBOOT_CAUSE_FILE="/var/cache/sonic/reboot-cause.txt"
 
 function stop_sonic_services()
 {
-    echo "Stopping syncd process..."
-    docker exec -i syncd /usr/bin/syncd_request_shutdown --cold > /dev/null
-    sleep 3
+    if [[ x"$ASIC_TYPE" != x"mellanox" ]]; then
+        echo "Stopping syncd process..."
+        docker exec -i syncd /usr/bin/syncd_request_shutdown --cold > /dev/null
+        sleep 3
+    fi
 }
 
 function clear_warm_boot()


### PR DESCRIPTION
* Don't send "syncd_request_shutdown" event for "cold" reboot on Mellanox platforms

Signed-off-by: Volodymyr Samotiy <volodymyrs@mellanox.com>

<!--
Please make sure you've read and understood our contributing guidelines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "closes #xxxx",
"fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
issue when the PR is merged

Please provide the following information:
-->

**- What I did**
Fixed reload flow for syncd on Mellanox platforms.
**- How I did it**
Currently there are problems for syncd stop/start flow on Mellanox platforms which cause errors during switch shutdown.

* For now Mellanox SAI ```remove_switch``` API doesn't have full support and returns an error on ```cold``` reboot (currently need to remove all config and then call switch remove). So, to fix the problem changed ```syncd.sh``` stop flow in order to not send ```syncd_request_shutdown``` event for ```cold``` reboot.

_**Note:** All changes are relevant only for Mellanox and doesn't change behavior for other platforms._

**- How to verify it**
Deploy an image and verify that the following is working without any problems and errors during shutdown/start flow:
* ```reboot```
* ```config load_minigraph```
* ```config reload```
* ```systemctl restart swss```

**- Previous command output (if the output of a command-line utility has changed)**
N/A
**- New command output (if the output of a command-line utility has changed)**
N/A

