### PR TITLE
[vnet_route_check] Align DB data parse logic with format used by swss…

### DIFF
--- a/scripts/vnet_route_check.py
+++ b/scripts/vnet_route_check.py
@@ -93,7 +93,7 @@ def get_vnet_intfs():
     vnet_intfs = {}
 
     for intf_key in intfs_keys:
-        intf_attrs = intfs_table.get(intf_key)[1]
+        intf_attrs = dict(intfs_table.get(intf_key)[1])
 
         if 'vnet_name' in intf_attrs:
             vnet_name = intf_attrs['vnet_name']
@@ -110,14 +110,9 @@ def get_all_rifs_oids():
     Format: { <rif_name>: <rif_oid> }
     '''
     db = swsscommon.DBConnector('COUNTERS_DB', 0)
-
     rif_table = swsscommon.Table(db, 'COUNTERS_RIF_NAME_MAP')
-    rif_keys = rif_table.getKeys()
 
-    rif_name_oid_map = {}
-
-    for rif_name in rif_keys:
-        rif_name_oid_map[rif_name] = rif_table.get(rif_name)[1]
+    rif_name_oid_map = dict(rif_table.get('')[1])
 
     return rif_name_oid_map
 
@@ -156,8 +151,8 @@ def get_vrf_entries():
         db_keys = rif_table.getKeys()
 
         for db_key in db_keys:
-            if 'SAI_OBJECT_TYPE_ROUTER_INTERFACE' in db_key:
-                rif_attrs = rif_table.get(db_key)[1]
+            if (db_key == f'SAI_OBJECT_TYPE_ROUTER_INTERFACE:{vnet_rifs_oids[vnet_rif_name]}'):
+                rif_attrs = dict(rif_table.get(db_key)[1])
                 rif_vrf_map[vnet_rif_name] = rif_attrs['SAI_ROUTER_INTERFACE_ATTR_VIRTUAL_ROUTER_ID']
 
     return rif_vrf_map

--- a/tests/vnet_route_check_test.py
+++ b/tests/vnet_route_check_test.py
@@ -254,7 +254,7 @@ class Table:
         return list(self.data.keys())
 
     def get(self, key):
-        ret = copy.deepcopy(self.data.get(key, {}))
+        ret = copy.deepcopy(self.data.get(key, self.data))
         return (True, ret)
 
 


### PR DESCRIPTION
…common API

* swsscommon API was changed in order to return data from DB as a tuple instead of dictionary.
* In some places vnet_route_check still was expecting data from DB in old format - as a dictionary.
* But now it is a tuple, so as a result vnet_route_check was failing with "KeyError" exeption.
* These changes fixed all the places in vnet_route_check script that used invalid data format.

Signed-off-by: Volodymyr Samotiy <volodymyrs@nvidia.com>

<!--
    Please make sure you've read and understood our contributing guidelines:
    https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

    ** Make sure all your commits include a signature generated with `git commit -s` **

    If this is a bug fix, make sure your description includes "closes #xxxx",
    "fixes #xxxx" or "resolves #xxxx" so that GitHub automatically closes the related
    issue when the PR is merged.

    If you are adding/modifying/removing any command or utility script, please also
    make sure to add/modify/remove any unit tests from the tests
    directory as appropriate.

    If you are modifying or removing an existing 'show', 'config' or 'sonic-clear'
    subcommand, or you are adding a new subcommand, please make sure you also
    update the Command Line Reference Guide (doc/Command-Reference.md) to reflect
    your changes.

    Please provide the following information:
-->

#### What I did

#### How I did it

#### How to verify it

#### Previous command output (if the output of a command-line utility has changed)

#### New command output (if the output of a command-line utility has changed)

